### PR TITLE
Fix link date generation

### DIFF
--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -33,6 +33,8 @@ class Link extends Model
     protected $casts = [
         'id' => 'integer',
         'event_id' => 'integer',
+        'start_date' => 'datetime',
+        'end_date' => 'datetime',
     ];
 
     public function event(): BelongsTo

--- a/database/factories/LinkFactory.php
+++ b/database/factories/LinkFactory.php
@@ -21,11 +21,14 @@ class LinkFactory extends Factory
      */
     public function definition(): array
     {
+        $start = $this->faker->dateTimeBetween('-1 week', 'now');
+        $end = $this->faker->dateTimeBetween($start, '+1 week');
+
         return [
             'event_id' => Event::factory(),
             'url' => $this->faker->url(),
-            'start_date' => $this->faker->dateTime(),
-            'end_date' => $this->faker->dateTime(),
+            'start_date' => $start,
+            'end_date' => $end,
         ];
     }
 }


### PR DESCRIPTION
## Summary
- generate end dates after start dates in `LinkFactory`
- cast `start_date` and `end_date` to datetime in `Link`

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c67cf56d8832c954de1ddb9068610